### PR TITLE
Fix a minor typo on the landing page

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -9,7 +9,7 @@ Welcome to the CL Technical Reference.
 
 The goal of this project is to provide a full technical reference that can be useful to anyone programming in Common Lisp.
 
-This document is comprised of both the original Common Lisp specification, and community provided explanations and examples to make it easier to understand.
+This document is comprised of both the original Common Lisp specification, and community-provided explanations and examples to make it easier to understand.
 
 If you have any ideas, please help us with an issue on GitHub or better yet, make a pull request!
 
@@ -18,5 +18,5 @@ Thank you and we hope you find this useful.
 Lisp Docs
 
 :::tip
-Some **Code Blocks** and **Tables** have not yet been chanegd to [Markdown Syntax](https://commonmark.org/help/), please help us fix the syntax whenever you notice text that needs to be fixed. Note that we use [MDX](https://docusaurus.io/docs/markdown-features) instead of vanilla markdown which means `<`, `>`, `{`, `}` are reserved and you can use React!
+Some **Code Blocks** and **Tables** have not yet been changed to [Markdown Syntax](https://commonmark.org/help/), please help us fix the syntax whenever you notice text that needs to be fixed. Note that we use [MDX](https://docusaurus.io/docs/markdown-features) instead of vanilla markdown which means `<`, `>`, `{`, `}` are reserved and you can use React!
 :::


### PR DESCRIPTION
Something I noticed when browsing the docs.