### PR TITLE
Fix formatting of `gethash` examples

### DIFF
--- a/docs/chap-18/bi-c-dictionary/_gethash_accessor.md
+++ b/docs/chap-18/bi-c-dictionary/_gethash_accessor.md
@@ -8,12 +8,10 @@
 
 <DictionaryLink  term={"gethash"}><b>gethash</b></DictionaryLink> *key hash-table* &amp;optional *default → value, present-p* 
 
-
-
 <!-- **(setf (gethash** *key hash-table* &amp;optional *default<DictionaryLink  term={"t"}><b>*)</b></DictionaryLink> *new-value***)**  -->
-**(setf (gethash** *key hash-table* &amp;optional *default***)** *new-value***)** 
-
-
+```
+(setf (gethash key hash-table &optional default) new-value)
+```
 
 **Arguments and Values:** 
 

--- a/docs/chap-18/bi-c-dictionary/gethash_accessor.md
+++ b/docs/chap-18/bi-c-dictionary/gethash_accessor.md
@@ -15,5 +15,8 @@ TODO: Please contribute to this page by adding explanations and examples
 :::
 
 ```lisp
-(gethash )
+(let ((ht (make-hash-table :test #'equal)))
+  (setf (gethash :foo ht) 1)
+  (gethash :foo ht))
+;; => 1, T
 ```


### PR DESCRIPTION
I'm on a work computer where the `node` version is way too old, so I was unable to test this myself, but either way the current rendering online is quite strange, and this PR is an attempt to fix that:

https://lisp-docs.github.io/cl-language-reference/chap-18/bi-c-dictionary/gethash_accessor

Overall the syntax examples on these pages could perhaps be improve en masse by using code fences.